### PR TITLE
Update for Webpack 4

### DIFF
--- a/lib/PrependPlugin.js
+++ b/lib/PrependPlugin.js
@@ -1,42 +1,68 @@
+/*
+    MIT License http://www.opensource.org/licenses/mit-license.php
+*/
+
 "use strict";
-var ConcatSource = require('webpack-sources/lib/ConcatSource');
-var fs = require('fs');
+
+const fs = require("fs");
+const validateOptions = require("schema-utils");
+const { ConcatSource } = require("webpack-sources");
+const ModuleFilenameHelpers = require("webpack/lib/ModuleFilenameHelpers");
+
+const schema = require("../schemas/PrependPlugin.json");
 
 class PrependPlugin {
-    constructor(args) {
-        if (typeof args !== 'object') {
-            throw new TypeError('Argument "args" must be an object.');
+    /**
+     * @param {PrependPluginArgument} options options object
+     */
+    constructor(options) {
+        if (typeof options === "string") {
+            options = {
+                filePath: options,
+                entryOnly: true
+            };
         }
 
-        this.filePath = args.hasOwnProperty('filePath') ? args.filePath : null;
+        validateOptions(schema, options, {
+            name: "Prepend Plugin",
+            baseDataPath: "options"
+        });
+
+        this.options = options;
     }
 
+    /**
+     * @param {Compiler} compiler webpack compiler
+     * @returns {void}
+     */
     apply(compiler) {
-        const prependFile = (compilation, fileName) =>
-            compilation.assets[fileName] = new ConcatSource(
-                fs.readFileSync(this.filePath, 'utf8'),
-                compilation.assets[fileName]
-            );
+        const options = this.options;
+        const prependText = fs.readFileSync(this.options.filePath, 'utf8');
+        const matchObject = ModuleFilenameHelpers.matchObject.bind(
+            undefined,
+            options
+        );
 
-        const wrapChunks = (compilation, chunks) =>
-            chunks.forEach(chunk => {
-                if (chunk.hasRuntime() && chunk.name) {
-                    chunk.files.forEach(fileName => {
-                        if (fileName.match(/\.js$/)) {
-                            prependFile(compilation, fileName)
+        compiler.hooks.compilation.tap("PrependPlugin", compilation => {
+            compilation.hooks.optimizeChunkAssets.tap("PrependPlugin", chunks => {
+                for (const chunk of chunks) {
+                    if (options.entryOnly && !chunk.canBeInitial()) {
+                        continue;
+                    }
+
+                    for (const file of chunk.files) {
+                        if (!matchObject(file)) {
+                            continue;
                         }
-                    });
+
+                        compilation.updateAsset(
+                            file,
+                            old => new ConcatSource(prependText, "\n", old)
+                        );
+                    }
                 }
             });
-
-        if (this.filePath) {
-            compiler.plugin('compilation', compilation =>
-                compilation.plugin('optimize-chunk-assets', (chunks, done) => {
-                    wrapChunks(compilation, chunks);
-                    done();
-                })
-            );
-        }
+        });
     }
 }
 

--- a/lib/PrependPlugin.js
+++ b/lib/PrependPlugin.js
@@ -8,6 +8,7 @@ const fs = require("fs");
 const validateOptions = require("schema-utils");
 const { ConcatSource } = require("webpack-sources");
 const ModuleFilenameHelpers = require("webpack/lib/ModuleFilenameHelpers");
+const Compilation = require("webpack/lib/Compilation")
 
 const schema = require("../schemas/PrependPlugin.json");
 
@@ -44,8 +45,11 @@ class PrependPlugin {
         );
 
         compiler.hooks.compilation.tap("PrependPlugin", compilation => {
-            compilation.hooks.optimizeChunkAssets.tap("PrependPlugin", chunks => {
-                for (const chunk of chunks) {
+            compilation.hooks.processAssets.tap({
+                name: "PrependPlugin",
+                stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_COMPATIBILITY
+            }, () => {
+                for (const chunk of compilation.chunks) {
                     if (options.entryOnly && !chunk.canBeInitial()) {
                         continue;
                     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "prepend-webpack-plugin",
+  "version": "3.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+    },
+    "ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "schema-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+      "requires": {
+        "ajv": "^6.1.0",
+        "ajv-errors": "^1.0.0",
+        "ajv-keywords": "^3.1.0"
+      }
+    },
+    "uri-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prepend-webpack-plugin",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Prepends file contents to entry chunks",
   "main": "lib/PrependPlugin.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/Irmiz/webpack-prepend-plugin/issues"
   },
-  "homepage": "https://github.com/Irmiz/webpack-prepend-plugin#readme"
+  "homepage": "https://github.com/Irmiz/webpack-prepend-plugin#readme",
+  "dependencies": {
+    "schema-utils": "^1.0.0"
+  }
 }

--- a/schemas/PrependPlugin.json
+++ b/schemas/PrependPlugin.json
@@ -1,0 +1,88 @@
+{
+  "definitions": {
+    "Rule": {
+      "description": "Filtering rule as regex or string.",
+      "anyOf": [
+        {
+          "instanceof": "RegExp",
+          "tsType": "RegExp"
+        },
+        {
+          "type": "string",
+          "minLength": 1
+        }
+      ]
+    },
+    "Rules": {
+      "description": "Filtering rules.",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "description": "A rule condition.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Rule"
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "#/definitions/Rule"
+        }
+      ]
+    }
+  },
+  "title": "PrependPluginArgument",
+  "anyOf": [
+    {
+      "description": "The path to the file to include.",
+      "type": "string",
+      "minLength": 1
+    },
+    {
+      "title": "PrependPluginOptions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "filePath": {
+          "description": "Specifies the path to the file to include.",
+          "anyOf": [
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "entryOnly": {
+          "description": "If true, the file will only be added to the entry chunks.",
+          "type": "boolean"
+        },
+        "exclude": {
+          "description": "Exclude all modules matching any of these conditions.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Rules"
+            }
+          ]
+        },
+        "include": {
+          "description": "Include all modules matching any of these conditions.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Rules"
+            }
+          ]
+        },
+        "test": {
+          "description": "Include all modules that pass test assertion.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Rules"
+            }
+          ]
+        }
+      },
+      "required": ["filePath"]
+    }
+  ]
+}


### PR DESCRIPTION
This basically re-writes the plugin based on the BannerPlugin built in to Webpack 4. However, it does remove the unneeded (and problematic) text substitution in BannerPlugin and preserves the options syntax of the current version.

Also now supported are "include"/"exclude" options that can be used to limit the prepending to only certain chunk files.

I'm fairly new to webpack, so I'm not super familiar with how the project has changed over the years. Let me know if you see any backwards-compatibility issues with this, or if you think this would be better off published as a new module.